### PR TITLE
pass arguments for individual target

### DIFF
--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -64,7 +64,7 @@ func isOverrideableBazelFlag(arg string) bool {
 	return false
 }
 
-func parseArgs(in []string) (targets, bazelArgs, args []string) {
+func parseArgs(in []string) (targets, bazelArgs, args []string, debugArgs [][]string) {
 	afterDoubleDash := false
 	for _, arg := range in {
 		if afterDoubleDash {
@@ -84,7 +84,16 @@ func parseArgs(in []string) (targets, bazelArgs, args []string) {
 			}
 
 			// If none of those things then it's probably a target.
-			targets = append(targets, arg)
+			if strings.HasPrefix(arg, "--arg") {
+				parsedArg := strings.Replace(arg, "--arg=", "", -1)
+				if strings.Contains(parsedArg, " ") {
+					parsedArg = "\"" + parsedArg + "\""
+				}
+				debugArgs[len(debugArgs)-1] = append(debugArgs[len(debugArgs)-1], parsedArg)
+			} else {
+				targets = append(targets, arg)
+				debugArgs = append(debugArgs, []string{})
+			}
 		}
 	}
 	return
@@ -124,7 +133,7 @@ func main() {
 }
 
 func handle(i *IBazel, command string, args []string) {
-	targets, bazelArgs, args := parseArgs(args)
+	targets, bazelArgs, args, debugArgs := parseArgs(args)
 	i.SetBazelArgs(bazelArgs)
 
 	switch command {
@@ -136,7 +145,7 @@ func handle(i *IBazel, command string, args []string) {
 		// Run only takes one argument
 		i.Run(targets[0], args)
 	case "mrun":
-		i.RunMulitple(args, targets...)
+		i.RunMulitple(args, targets, debugArgs)
 	default:
 		fmt.Fprintf(os.Stderr, "Asked me to perform %s. I don't know how to do that.", command)
 		usage()


### PR DESCRIPTION
# iBazel Takes Arguments For Individual Target
Add the option to pass arguments to individual target by `mrun` command. The arguments should follow the target, arguments should start with `--arg=` and can be as many as you want. Use quotes if the argument contains whitespace.

## Command Example:
`ibazel mrun t1 --arg=t1_arg1 t2 --arg=t2_arg1 --arg="t2 arg2" -- common_arg`