### PR TITLE
Stop serving old source code right when new code builds

### DIFF
--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -35,7 +35,8 @@ var bazelNew = bazel.New
 type Command interface {
 	Start(logFile *os.File) (*bytes.Buffer, error)
 	Terminate()
-	NotifyOfChanges(logFile *os.File) *bytes.Buffer
+	BeforeRebuild()
+	AfterRebuild(logFile *os.File) *bytes.Buffer
 	IsSubprocessRunning() bool
 }
 

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -80,8 +80,11 @@ func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *defaultCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
+func (c *defaultCommand) BeforeRebuild() {
 	c.Terminate()
+}
+
+func (c *defaultCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {
 	outputBuffer, _ := c.Start(logFile)
 	return outputBuffer
 }

--- a/ibazel/command/default_command_test.go
+++ b/ibazel/command/default_command_test.go
@@ -60,7 +60,8 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	// This is synonymous with killing the job so use it to kill the job and test everything.
-	c.NotifyOfChanges(nil)
+	c.BeforeRebuild()
+	c.AfterRebuild(nil)
 	assertKilled(t, toKill.RootProcess())
 }
 

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -88,18 +88,21 @@ func (c *notifyCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
+func (c *notifyCommand) BeforeRebuild() {
+	_, err := c.stdin.Write([]byte("IBAZEL_BUILD_STARTED\n"))
+	if err != nil {
+		log.Errorf("Error writing build to stdin: %s", err)
+	}
+}
+
+
+func (c *notifyCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
 
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
-
-	_, err := c.stdin.Write([]byte("IBAZEL_BUILD_STARTED\n"))
-	if err != nil {
-		log.Errorf("Error writing build to stdin: %s", err)
-	}
 
 	outputBuffer, res := b.Build(c.target)
 	if res != nil {

--- a/ibazel/command/notify_command_test.go
+++ b/ibazel/command/notify_command_test.go
@@ -49,11 +49,11 @@ func TestNotifyCommand(t *testing.T) {
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
-	c.NotifyOfChanges(nil)
+	c.AfterRebuild(nil)
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges(nil)
+	c.AfterRebuild(nil)
 	b.BuildError(nil)
-	c.NotifyOfChanges(nil)
+	c.AfterRebuild(nil)
 
 	b.AssertActions(t, [][]string{
 		[]string{"WriteToStderr"},

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -432,6 +432,12 @@ func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands
 			i.state = RUN
 		}
 	case RUN:
+		if i.cmds != nil {
+			for _, target := range targets {
+				i.cmds[target].BeforeRebuild()
+			}
+		}
+
 		var torun []string
 		if i.prevDir != "" && i.firstBuildPassed {
 			torun = i.srcDirToWatch[i.prevDir]
@@ -563,7 +569,7 @@ func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
 	}
 
 	log.Logf("Notifying of changes")
-	outputBuffer := i.cmd.NotifyOfChanges(nil)
+	outputBuffer := i.cmd.AfterRebuild(nil)
 	return outputBuffer, nil
 }
 
@@ -596,7 +602,7 @@ func (i *IBazel) runMultiple(targets []string, debugArgs [][]string, argsLength 
 	}
 	log.Logf("Notifying of changes")
 	for _, target := range targets {
-		outputBuffers = append(outputBuffers, i.cmds[target].NotifyOfChanges(i.logFiles[target]))
+		outputBuffers = append(outputBuffers, i.cmds[target].AfterRebuild(i.logFiles[target]))
 	}
 	return outputBuffers, nil
 }

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -438,7 +438,8 @@ func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands
 		} else {
 			torun = targets
 		}
-		log.Logf("%sing %s", strings.Title(command), strings.Join(torun, " "))
+		
+		log.Logf("%s %s", strings.Title(verb(command)), strings.Join(torun, " "))
 		i.beforeCommand(torun, command)
 		outputBuffers, err := commandToRun(torun, debugArgs, argsLength)
 		for _, buffer := range outputBuffers {
@@ -453,6 +454,8 @@ func verb(s string) string {
 	switch s {
 	case "run":
 		return "running"
+	case "Run":
+		return "Running"
 	default:
 		return fmt.Sprintf("%sing", s)
 	}

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -282,10 +282,10 @@ func (i *IBazel) Run(target string, args []string) error {
 }
 
 // Run the specified target (singular) in the IBazel loop.
-func (i *IBazel) RunMulitple(args, target []string, debugArgs [][]string) error {
+func (i *IBazel) RunMultiple(args, target []string, debugArgs [][]string) error {
 	i.args = args
 	argsLength := len(args)
-	return i.loopMultiple("run", i.runMulitple, target, debugArgs, argsLength)
+	return i.loopMultiple("run", i.runMultiple, target, debugArgs, argsLength)
 }
 
 // Build the specified targets in the IBazel loop.
@@ -567,7 +567,7 @@ func (i *IBazel) run(targets ...string) (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (i *IBazel) runMulitple(targets []string, debugArgs [][]string, argsLength int) ([]*bytes.Buffer, error) {
+func (i *IBazel) runMultiple(targets []string, debugArgs [][]string, argsLength int) ([]*bytes.Buffer, error) {
 	var outputBuffers []*bytes.Buffer
 	log.Logf("Rebuilding changed targets")
 	outputBufferBuild, errBuild := i.build(targets...)

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -81,7 +81,7 @@ func (m *mockCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	m.started = true
 	return nil, nil
 }
-func (m *mockCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
+func (m *mockCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {
 	m.notifiedOfChanges = true
 	return nil
 }

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -199,7 +199,7 @@ func handle(i *IBazel, command string, args []string) {
 		// Run only takes one argument
 		i.Run(targets[0], args)
 	case "mrun":
-		i.RunMulitple(args, targets, debugArgs)
+		i.RunMultiple(args, targets, debugArgs)
 	default:
 		fmt.Fprintf(os.Stderr, "Asked me to perform %s. I don't know how to do that.", command)
 		usage()


### PR DESCRIPTION
Most of the changes make old code processes terminate as soon as we know we are rebuilding (this should help developers see their changes better). There are also small grammar/spelling changes.