### PR TITLE
Add log messages to explain iBazel time usage

### DIFF
--- a/.bazel_fix_commands.json
+++ b/.bazel_fix_commands.json
@@ -1,0 +1,5 @@
+[{
+    "regex": "^Check that imports in Go sources match importpath attributes in deps.$",
+    "command": "bazel",
+    "args":    ["run", "//:gazelle"]
+}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Change Log
 
+## [v0.13.0](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/tree/v0.13.0) (2020-04-24)
+[Full Changelog](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/compare/v0.12.4...v0.13.0)
+
+**Fixed bugs:**
+
+- Reads .bazel\_fix\_commands.json from current directory [\#373](https://github.com/bazelbuild/bazel-watcher/issues/373)
+
+**Closed issues:**
+
+- Proposal:  use bazel's cquery in place of query for queryForSourceFiles checks [\#305](https://github.com/bazelbuild/bazel-watcher/issues/305)
+- ibazel run on container\_image does not work [\#245](https://github.com/bazelbuild/bazel-watcher/issues/245)
+- ibazel run crash doesn't shut down ts\_devserver [\#197](https://github.com/bazelbuild/bazel-watcher/issues/197)
+
+**Merged pull requests:**
+
+- Fix output\_runner to read from %WORKSPACE [\#375](https://github.com/bazelbuild/bazel-watcher/pull/375) ([achew22](https://github.com/achew22))
+- Switch to cquery instead of query [\#374](https://github.com/bazelbuild/bazel-watcher/pull/374) ([achew22](https://github.com/achew22))
+- Update module golang/protobuf to v1.4.0 [\#372](https://github.com/bazelbuild/bazel-watcher/pull/372) ([renovate-bot](https://github.com/renovate-bot))
+
+## [v0.12.4](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/tree/v0.12.4) (2020-04-09)
+[Full Changelog](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/compare/v0.12.3...v0.12.4)
+
+**Fixed bugs:**
+
+- Full log not being shown on initial querying [\#217](https://github.com/bazelbuild/bazel-watcher/issues/217)
+- Support for passing flags to bazel is limited and undocumented [\#126](https://github.com/bazelbuild/bazel-watcher/issues/126)
+
+**Closed issues:**
+
+- bazeliskNpmPath: should check if @bazel/bazelisk binary exists? [\#370](https://github.com/bazelbuild/bazel-watcher/issues/370)
+- Bazelisk regression [\#352](https://github.com/bazelbuild/bazel-watcher/issues/352)
+- \[Windows\] - Querying for files to watch... \)\) was unexpected at this time. Bazel query failed: exit status 255 [\#344](https://github.com/bazelbuild/bazel-watcher/issues/344)
+
+**Merged pull requests:**
+
+- Fix a lingering TODO [\#362](https://github.com/bazelbuild/bazel-watcher/pull/362) ([achew22](https://github.com/achew22))
+- Stamp can be passed without a value [\#361](https://github.com/bazelbuild/bazel-watcher/pull/361) ([achew22](https://github.com/achew22))
+- Update module golang/protobuf to v1.3.5 [\#359](https://github.com/bazelbuild/bazel-watcher/pull/359) ([renovate-bot](https://github.com/renovate-bot))
+- Update module fsnotify/fsnotify to v1.4.9 [\#357](https://github.com/bazelbuild/bazel-watcher/pull/357) ([renovate-bot](https://github.com/renovate-bot))
+- Update dependency com\_github\_bazelbuild\_rules\_go to v0.22.1 [\#354](https://github.com/bazelbuild/bazel-watcher/pull/354) ([renovate-bot](https://github.com/renovate-bot))
+
 ## [v0.12.3](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/tree/v0.12.3) (2020-03-14)
 [Full Changelog](https://github.com/bazelbuild/bazel-watcher/bazelbuild/bazel-watcher/compare/v0.12.2...v0.12.3)
 

--- a/README.md
+++ b/README.md
@@ -76,22 +76,45 @@ stdin.
 
 ## Output Runner
 
-iBazel is capable of producing and running commands from the output of Bazel commands. If iBazel is run with the flag `--run_output` then it will check for a `%WORKSPACE%/.bazel_fix_commands.json` and if present run any commands that match the provided regular expressions.
-For example the commands defined by the following file will match `buildozer` commands found in the output and provide a prompt to run the command.
+iBazel is capable of producing and running commands from the output of Bazel
+commands. If iBazel is run with the flag `--run_output` then it will check for
+a `%WORKSPACE%/.bazel_fix_commands.json` and if present run any commands that
+match the provided regular expressions.  For example the commands defined by
+the following file will match `buildozer` commands found in the output and
+provide a prompt to run the command as well as invoke `bazel run //:gazelle` if
+it detects a missing import for your go code.
+
 ```
-[{
+[
+  {
+    "regex": "^Check that imports in Go sources match importpath attributes in deps.$",
+    "command": "bazel",
+    "args":    ["run", "//:gazelle"]
+  },
+  }
     "regex": "^buildozer '(.*)'\\s+(.*)$",
     "command": "buildozer",
     "args":    ["$1", "$2"],
-}]
+  }
+]
 ```
-Adding the flag `--run_output_interactive=false` will automatically run the command without prompting for confirmation.
-The fields in `.bazel_fix_commands.json` are:
 
-* regex: a regular expression that will be matched against every line of output.
-    * backslash `\` characters will need to be escaped once for the regex to be parsed properly.
+Adding the flag `--run_output_interactive=false` will automatically run the
+command without prompting for confirmation.  The fields in
+`.bazel_fix_commands.json` are:
+
+* regex: a regular expression that will be matched against every line of
+  output.
+    * backslash `\` characters will need to be escaped once for the regex to be
+      parsed properly.
 * command: a command that will be run from the workspace root.
-* args: a list of arguments to provide to the command, with `$1` being the first match group of `regex`, `$2` being the second and so on.
+* args: a list of arguments to provide to the command, with `$1` being the
+  first match group of `regex`, `$2` being the second and so on.
+
+You can disable this feature by adding flag `--run_output=false` or you can
+create a `.bazel_fix_commands.json` that contains an empty json array, `[]`.
+This will additionally disable the notification providing usage instructions on
+the first invocation of iBazel.
 
 ## Profiling
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,7 @@ rules_proto_toolchains()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# gazelle:repository go_repository name=com_github_bazelbuild_rules_go importpath=github.com/bazelbuild/rules_go
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "7b9bbe3ea1fccb46dcfa6c3f3e29ba7ec740d8733370e21cdc8937467b4a4349",
@@ -73,10 +74,11 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
 load(":repositories.bzl", "go_repositories")
 
+# gazelle:repository_macro repositories.bzl%go_repositories
 go_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,10 +51,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "e6a6c016b0663e06fa5fccf1cd8152eab8aa8180c583ec20c872f4f9953a7ac5",
+    sha256 = "7b9bbe3ea1fccb46dcfa6c3f3e29ba7ec740d8733370e21cdc8937467b4a4349",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.22.4/rules_go-v0.22.4.tar.gz",
     ],
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//third_party/bazel/master/src/main/protobuf/analysis:go_default_library",
         "//third_party/bazel/master/src/main/protobuf/blaze_query:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "//ibazel/log:go_default_library",
     ],
 )
 

--- a/bazel/bazel.go
+++ b/bazel/bazel.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bazelbuild/bazel-watcher/third_party/bazel/master/src/main/protobuf/blaze_query"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/bazelbuild/bazel-watcher/ibazel/log"
 )
 
 var bazelPathFlag = flag.String("bazel_path", "", "Path to the bazel binary to use for actions")
@@ -229,7 +230,7 @@ func (b *bazel) Info() (map[string]string, error) {
 	b.WriteToStderr(false)
 	b.WriteToStdout(false)
 	stdoutBuffer, _ := b.newCommand("info")
-
+	log.Logf("Running 'bazel info'...")
 	err := b.cmd.Run()
 	if err != nil {
 		return nil, err

--- a/e2e/output_runner/output_runner_test.go
+++ b/e2e/output_runner/output_runner_test.go
@@ -73,6 +73,13 @@ func TestOutputRunner(t *testing.T) {
 	checkSentinel(t, sentinelFile, "ioutil.TempFile creates the file by default. Delete it.")
 	checkNoSentinel(t, sentinelFile, "The sentinal should now be deleted.")
 
+	// First check that it doesn't run if there isn't a `.bazel_fix_commands.json` file.
+	ibazel := e2e.NewIBazelTester(t)
+	ibazel.RunWithBazelFixCommands("//:overwrite")
+
+	// Ensure it prints out the banner.
+	ibazel.ExpectIBazelError("Did you know")
+
 	e2e.MustWriteFile(t, ".bazel_fix_commands.json", fmt.Sprintf(`
 	[{
 		"regex": "^(.*)runacommand(.*)$",
@@ -84,7 +91,6 @@ func TestOutputRunner(t *testing.T) {
 printf "overwrite1"
 `)
 
-	ibazel := e2e.NewIBazelTester(t)
 	ibazel.RunWithBazelFixCommands("//:overwrite")
 
 	ibazel.ExpectOutput("overwrite1")

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -58,7 +58,7 @@ func (c *defaultCommand) Terminate() {
 	c.pg = nil
 }
 
-func (c *defaultCommand) Start() (*bytes.Buffer, error) {
+func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
@@ -67,7 +67,7 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	b.WriteToStdout(true)
 
 	var outputBuffer *bytes.Buffer
-	outputBuffer, c.pg = start(b, c.target, c.args)
+	outputBuffer, c.pg = start(b, c.target, c.args, logFile)
 
 	c.pg.RootProcess().Env = os.Environ()
 
@@ -80,10 +80,10 @@ func (c *defaultCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *defaultCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *defaultCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	c.Terminate()
-	c.Start()
-	return nil
+	outputBuffer, _ := c.Start(logFile)
+	return outputBuffer
 }
 
 func (c *defaultCommand) IsSubprocessRunning() bool {

--- a/ibazel/command/default_command_test.go
+++ b/ibazel/command/default_command_test.go
@@ -60,7 +60,7 @@ func TestDefaultCommand(t *testing.T) {
 	}
 
 	// This is synonymous with killing the job so use it to kill the job and test everything.
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	assertKilled(t, toKill.RootProcess())
 }
 
@@ -77,7 +77,7 @@ func TestDefaultCommand_Start(t *testing.T) {
 
 	b := &mock_bazel.MockBazel{}
 
-	_, pg := start(b, "//path/to:target", []string{"moo"})
+	_, pg := start(b, "//path/to:target", []string{"moo"}, nil)
 	pg.Start()
 
 	if pg.RootProcess().Stdout != os.Stdout {

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -60,7 +60,7 @@ func (c *notifyCommand) Terminate() {
 	c.pg = nil
 }
 
-func (c *notifyCommand) Start() (*bytes.Buffer, error) {
+func (c *notifyCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)
@@ -69,7 +69,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	b.WriteToStdout(true)
 
 	var outputBuffer *bytes.Buffer
-	outputBuffer, c.pg = start(b, c.target, c.args)
+	outputBuffer, c.pg = start(b, c.target, c.args, logFile)
 	// Keep the writer around.
 	var err error
 	c.stdin, err = c.pg.RootProcess().StdinPipe()
@@ -88,7 +88,7 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 	return outputBuffer, nil
 }
 
-func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+func (c *notifyCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)

--- a/ibazel/command/notify_command_test.go
+++ b/ibazel/command/notify_command_test.go
@@ -49,11 +49,11 @@ func TestNotifyCommand(t *testing.T) {
 	bazelNew = func() bazel.Bazel { return b }
 	defer func() { bazelNew = oldBazelNew }()
 
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(errors.New("Demo error"))
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 	b.BuildError(nil)
-	c.NotifyOfChanges()
+	c.NotifyOfChanges(nil)
 
 	b.AssertActions(t, [][]string{
 		[]string{"WriteToStderr"},

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -536,6 +536,13 @@ func (i *IBazel) setupRun(target string, debugArg []string, argsLength int) comm
 		log.Logf("Launching with notifications")
 		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	} else {
+		// argsLength == -1 when the command is `run`
+		// no need to modify i.args
+		if len(debugArg) > 0 {
+			i.args = append(debugArg, i.args[len(i.args)-argsLength:len(i.args)]...)
+		} else if argsLength > -1 {
+			i.args = i.args[len(i.args)-argsLength:len(i.args)]
+		}
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
 }

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -92,6 +92,7 @@ type IBazel struct {
 }
 
 func New() (*IBazel, error) {
+	log.Logf("Initializing iBazel struct i...")
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -74,14 +74,14 @@ type mockCommand struct {
 	terminated        bool
 }
 
-func (m *mockCommand) Start() (*bytes.Buffer, error) {
+func (m *mockCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	if m.started {
 		panic("Can't run command twice")
 	}
 	m.started = true
 	return nil, nil
 }
-func (m *mockCommand) NotifyOfChanges() *bytes.Buffer {
+func (m *mockCommand) NotifyOfChanges(logFile *os.File) *bytes.Buffer {
 	m.notifiedOfChanges = true
 	return nil
 }
@@ -239,6 +239,81 @@ func TestIBazelLoop(t *testing.T) {
 	assertState(WAIT)
 }
 
+func TestIBazelLoopMultiple(t *testing.T) {
+	i := newIBazel(t)
+
+	// Replace the file watching channel with one that has a buffer.
+	i.buildFileWatcher = &fakeFSNotifyWatcher{
+		EventChan: make(chan fsnotify.Event, 1),
+	}
+	i.sourceEventHandler.SourceFileEvents = make(chan fsnotify.Event, 1)
+
+	defer i.Cleanup()
+
+	// The process for testing this is going to be to emit events to the channels
+	// that are associated with these objects and walk the state transition
+	// graph.
+
+	// First let's consume all the events from all the channels we care about
+	called := false
+	command := func(targets []string, debugArgs [][]string, argsLength int) ([]*bytes.Buffer, error) {
+		called = true
+		return nil, nil
+	}
+
+	i.state = QUERY
+	step := func() {
+		i.iterationMultiple("demo", command, []string{}, [][]string{}, 0)
+	}
+	assertRun := func() {
+		if called == false {
+			_, file, line, _ := runtime.Caller(1) // decorate + log + public function.
+			t.Errorf("%s:%v Should have run the provided comand", file, line)
+		}
+		called = false
+	}
+	assertState := func(state State) {
+		if i.state != state {
+			_, file, line, _ := runtime.Caller(1) // decorate + log + public function.
+			t.Errorf("%s:%v Expected state to be %s but was %s", file, line, state, i.state)
+		}
+	}
+
+	// Pretend a fairly normal event chain happens.
+	// Start, run the program, write a source file, run, write a build file, run.
+
+	assertState(QUERY)
+	step()
+	i.filesWatched[i.buildFileWatcher] = map[string]struct{}{"/path/to/BUILD": struct{}{}}
+	i.filesWatched[i.sourceFileWatcher] = map[string]struct{}{"/path/to/foo": struct{}{}}
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+	// Source file change.
+	i.sourceEventHandler.SourceFileEvents <- fsnotify.Event{Op: fsnotify.Write, Name: "/path/to/foo"}
+	step()
+	assertState(DEBOUNCE_RUN)
+	step()
+	// Don't send another event in to test the timer
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+	// Build file change.
+	i.buildFileWatcher.Events() <- fsnotify.Event{Op: fsnotify.Write, Name: "/path/to/BUILD"}
+	step()
+	assertState(DEBOUNCE_QUERY)
+	// Don't send another event in to test the timer
+	step()
+	assertState(QUERY)
+	step()
+	assertState(RUN)
+	step() // Actually run the command
+	assertRun()
+	assertState(WAIT)
+}
+
 func TestIBazelBuild(t *testing.T) {
 	i := newIBazel(t)
 	defer i.Cleanup()
@@ -341,7 +416,7 @@ func TestHandleSignals_SIGINT(t *testing.T) {
 	// dead to test the job not responding)
 	for j := 0; j < 2; j++ {
 		cmd = &mockCommand{}
-		cmd.Start()
+		cmd.Start(nil)
 		i.cmd = cmd
 
 		// This should kill the subprocess and simulate hitting ctrl-c
@@ -378,7 +453,7 @@ func TestHandleSignals_SIGTERM(t *testing.T) {
 	attemptedExit = false
 
 	cmd := &mockCommand{}
-	cmd.Start()
+	cmd.Start(nil)
 	i.cmd = cmd
 
 	i.sigs <- syscall.SIGTERM

--- a/ibazel/log/log.go
+++ b/ibazel/log/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -14,18 +15,18 @@ var osExit = os.Exit
 var timeNow = time.Now
 
 const (
-	reset color = "\033[0m"
-
-	errorColor color = "\033[31m"
-	fatalColor color = "\033[41m"
-	logColor   color = "\033[96m"
+	resetColor  color = "\033[0m"
+	bannerColor color = "\033[33m"
+	errorColor  color = "\033[31m"
+	fatalColor  color = "\033[41m"
+	logColor    color = "\033[96m"
 )
 
 func log(c color, msg string, args ...interface{}) {
 	fmt.Fprintf(writer, "%siBazel [%s]%s: ",
 		c,
 		timeNow().Local().Format(time.Kitchen),
-		reset)
+		resetColor)
 	fmt.Fprintf(writer, msg, args...)
 	fmt.Fprintf(writer, "\n")
 }
@@ -33,6 +34,22 @@ func log(c color, msg string, args ...interface{}) {
 // NewLine prints a new line to the screen without any preamble.
 func NewLine() {
 	fmt.Fprintf(writer, "\n")
+}
+
+// Print out a banner surrounded by # to draw attention to the eye.
+func Banner(lines ...string) {
+	NewLine()
+	fmt.Fprintf(writer, "%s%s%s", bannerColor, strings.Repeat("#", 80), resetColor)
+	NewLine()
+
+	for _, line := range lines {
+		fmt.Fprintf(writer, "%s#%s %-76s %s#%s", bannerColor, resetColor, line, bannerColor, resetColor)
+		NewLine()
+	}
+
+	fmt.Fprintf(writer, "%s%s%s", bannerColor, strings.Repeat("#", 80), resetColor)
+	NewLine()
+	NewLine()
 }
 
 // Error prints an error to the screen with a preamble.

--- a/ibazel/log/log_test.go
+++ b/ibazel/log/log_test.go
@@ -112,3 +112,23 @@ func TestNonfLoggers(t *testing.T) {
 		})
 	}
 }
+
+func TestBanner(t *testing.T) {
+	buf := &bytes.Buffer{}
+	SetWriter(buf)
+
+	Banner("This is multi", "line output that", "is expected to be printed")
+
+	got := buf.String()
+	want := fmt.Sprintf(`
+%s################################################################################%s
+%s#%s This is multi                                                                %s#%s
+%s#%s line output that                                                             %s#%s
+%s#%s is expected to be printed                                                    %s#%s
+%s################################################################################%s
+
+`, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor, bannerColor, resetColor)
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("\nGot:  %q\nWant: %q\nDiff:\n%s", got, want, diff)
+	}
+}

--- a/ibazel/main_test.go
+++ b/ibazel/main_test.go
@@ -26,21 +26,30 @@ func TestParsingArgs(t *testing.T) {
 		startupArgs []string
 		bazelArgs   []string
 		args        []string
+		debugArgs   [][]string
 	}{
 		// Empty case.
-		{[]string{}, nil, nil, nil, nil},
+		{[]string{}, nil, nil, nil, nil, nil},
+		// Only one target.
+		{[]string{"//my/target"}, []string{"//my/target"}, nil, nil, nil, [][]string{{}}},
 		// Only targets.
-		{[]string{"//my/target"}, []string{"//my/target"}, nil, nil, nil},
+		{[]string{"//my/target1", "//my/target2"}, []string{"//my/target1", "//my/target2"}, nil, nil, nil, [][]string{{},{}}},
 		// arguments after a --.
-		{[]string{"--", "--my_program_flag"}, nil, nil, nil, []string{"--my_program_flag"}},
+		{[]string{"--", "--my_program_flag"}, nil, nil, nil, []string{"--my_program_flag"}, nil},
 		// Whitelisted startup argument.
-		{[]string{"--bazelrc=/home/libsamek/bazelrc"}, nil, []string{"--bazelrc=/home/libsamek/bazelrc"}, nil, nil},
+		{[]string{"--bazelrc=/home/libsamek/bazelrc"}, nil, []string{"--bazelrc=/home/libsamek/bazelrc"}, nil, nil, nil},
 		// Whitelisted bazel flag.
-		{[]string{"--test_output=streaming"}, nil, nil, []string{"--test_output=streaming"}, nil},
+		{[]string{"--test_output=streaming"}, nil, nil, []string{"--test_output=streaming"}, nil, nil},
 		// Whitelisted bazel flag, arg, and target.
-		{[]string{"--test_output=streaming", "--", "--my_program_flag"}, nil, nil,[]string{"--test_output=streaming"}, []string{"--my_program_flag"}},
+		{[]string{"--test_output=streaming", "--", "--my_program_flag"}, nil, nil, []string{"--test_output=streaming"}, []string{"--my_program_flag"}, nil},
+		// Multiple targets with multiple arguments.
+		{[]string{"//my/target1", "--arg=t1_arg1", "--arg=t1_arg2", "//my/target2"}, []string{"//my/target1", "//my/target2"}, nil, nil, nil, [][]string{{"t1_arg1", "t1_arg2"},{}}},
+		// Multiple targets with single argument.
+		{[]string{"//my/target1", "--arg=t1_arg1", "//my/target2", "--arg=t2_arg1", "//my/target3", "--arg=t3_arg1"}, []string{"//my/target1", "//my/target2", "//my/target3"}, nil, nil, nil, [][]string{{"t1_arg1"}, {"t2_arg1"}, {"t3_arg1"}}},
+		// Multiple targets with argument with whitespace.
+		{[]string{"//my/target1", "--arg=t1 arg1", "//my/target2", "--arg=t2 arg1", "//my/target3"}, []string{"//my/target1", "//my/target2", "//my/target3"}, nil, nil, nil, [][]string{{"\"t1 arg1\""}, {"\"t2 arg1\""}, {}}},
 	} {
-		targets, startupArgs, bazelArgs, args := parseArgs(c.in)
+		targets, startupArgs, bazelArgs, args, debugArgs := parseArgs(c.in)
 		if !reflect.DeepEqual(c.targets, targets) {
 			t.Errorf("Targets not equal for args: %v\nGot:  %v\nWant: %v",
 				c.in, targets, c.targets)
@@ -56,6 +65,10 @@ func TestParsingArgs(t *testing.T) {
 		if !reflect.DeepEqual(c.args, args) {
 			t.Errorf("Additional args not equal for args: %v\nGot:  %v\nWant: %v",
 				c.in, args, c.args)
+		}
+		if !reflect.DeepEqual(c.debugArgs, debugArgs) {
+			t.Errorf("Debug args not equal for debugArgs: %v\nGot:  %v\nWant: %v",
+				c.in, debugArgs, c.debugArgs)
 		}
 	}
 }

--- a/ibazel/output_runner/BUILD
+++ b/ibazel/output_runner/BUILD
@@ -32,4 +32,5 @@ go_test(
     data = ["output_runner_test.json"],
     embed = [":go_default_library"],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel",
+    deps = ["//ibazel/workspace_finder:go_default_library"],
 )

--- a/ibazel/output_runner/output_runner_test.go
+++ b/ibazel/output_runner/output_runner_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/ibazel/workspace_finder"
 )
 
 func TestConvertArgs(t *testing.T) {
@@ -56,7 +58,10 @@ func TestConvertArgs(t *testing.T) {
 }
 
 func TestReadConfigs(t *testing.T) {
-	optcmd := readConfigs("output_runner_test.json")
+	i := &OutputRunner{
+		wf: &workspace_finder.FakeWorkspaceFinder{},
+	}
+	optcmd := i.readConfigs("output_runner_test.json")
 
 	for idx, c := range []struct {
 		regex   string
@@ -153,7 +158,7 @@ func TestMatchCleanRegex(t *testing.T) {
 			buf.WriteString(tt.in)
 			cmdLines, _, _ := matchRegex(optcmd, &buf)
 
-			if (!reflect.DeepEqual(cmdLines, tt.out)) {
+			if !reflect.DeepEqual(cmdLines, tt.out) {
 				t.Errorf("Commands not equal!\nGot:  %v\nWant: %v", cmdLines, tt.out)
 			}
 		})

--- a/release/release.sh
+++ b/release/release.sh
@@ -33,7 +33,6 @@ This will update the changelog, tag a release and release it.
 
 Press enter to continue
 EOF
-
 read
 
 docker run --rm \
@@ -50,9 +49,16 @@ docker run --rm \
       --unreleased-label "**Next release**" \
       --future-release="${GIT_TAG}"
 
+git checkout -b release
+
 # Add the newly generated changelog and commit it.
 git add CHANGELOG.md
 git commit -m "Generating CHANGELOG.md for release ${GIT_TAG}"
+
+cat - <<EOF
+Upload the current branch for review. Merge it, sync this branch and then hit enter.
+EOF
+read
 
 # Tag the release.
 git tag "${GIT_TAG}"

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -30,7 +30,7 @@ def go_repositories():
     go_repository(
         name = "com_github_bazelbuild_rules_go",
         importpath = "github.com/bazelbuild/rules_go",
-        tag = "v0.22.1",
+        tag = "v0.22.4",
     )
     go_repository(
         name = "com_github_jaschaephraim_lrserver",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -6,31 +6,26 @@ def go_repositories():
     go_repository(
         name = "com_github_fsnotify_fsnotify",
         importpath = "github.com/fsnotify/fsnotify",
-        sum = "h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=",
-        version = "v1.4.7",
+        sum = "h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=",
+        version = "v1.4.9",
     )
     go_repository(
         name = "com_github_golang_protobuf",
         importpath = "github.com/golang/protobuf",
-        sum = "h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=",
-        version = "v1.3.2",
+        sum = "h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=",
+        version = "v1.4.0",
     )
     go_repository(
         name = "com_github_google_go_cmp",
         importpath = "github.com/google/go-cmp",
-        sum = "h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=",
-        version = "v0.3.1",
+        sum = "h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=",
+        version = "v0.4.0",
     )
     go_repository(
         name = "com_github_gorilla_websocket",
         importpath = "github.com/gorilla/websocket",
         sum = "h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=",
         version = "v1.4.1",
-    )
-    go_repository(
-        name = "com_github_bazelbuild_rules_go",
-        importpath = "github.com/bazelbuild/rules_go",
-        tag = "v0.22.4",
     )
     go_repository(
         name = "com_github_jaschaephraim_lrserver",
@@ -43,4 +38,16 @@ def go_repositories():
         importpath = "golang.org/x/sys",
         sum = "h1:S/FtSvpNLtFBgjTqcKsRpsa6aVsI6iztaz1bQd9BJwE=",
         version = "v0.0.0-20191029155521-f43be2a4598c",
+    )
+    go_repository(
+        name = "org_golang_google_protobuf",
+        importpath = "google.golang.org/protobuf",
+        sum = "h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=",
+        version = "v1.21.0",
+    )
+    go_repository(
+        name = "org_golang_x_xerrors",
+        importpath = "golang.org/x/xerrors",
+        sum = "h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=",
+        version = "v0.0.0-20191204190536-9bdfabe68543",
     )


### PR DESCRIPTION
Sometimes when IBazel runs "bazel info", it can take a long time. This commit adds console messages so developers know what is going on.