### PR TITLE
Prevent ibazel from terminating processes twice

### DIFF
--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -81,7 +81,9 @@ func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 }
 
 func (c *defaultCommand) BeforeRebuild() {
-	c.Terminate()
+	if c.pg != nil {
+		c.Terminate()
+	}
 }
 
 func (c *defaultCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {


### PR DESCRIPTION
IBazel was segfaulting when a build file dependency changed, because it would kill a process, realize the compile didn't succeed, and try to kill the process again when the compile retried. This fixes that.