### PR TITLE
Apply graceful termination (bazelbuild#405) to lucid-master

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Justin Buchanan <justbuchanan@gmail.com>
 Markus Padourek <markus.padourek@gmail.com>
 Martin Probst <martinprobst@google.com>
 Matt Moore <mattmoor@google.com>
+Matti Mehtonen <matti@vanils.fi>
 mrmeku <mrmeku@gmail.com>
 Steren Giannini <steren.giannini@gmail.com>
 Vladimir Moskva <vladmos@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ When the profiler script is loaded, a `window.IBazelProfileEvent(eventType, data
 
 ### Termination
 
-SIGINT has to be sent twice to kill ibazel: once to kill the subprocess, and
-the second time for ibazel itself. Also, ibazel will exit on its own when a
+SIGINT has to be sent twice to kill ibazel: once to terminate the subprocess,
+and the second time for ibazel itself. Also, ibazel will exit on its own when a
 bazel query fails, but it will stay alive when a build, test, or run fails.
 We use an exit code of 3 for a signal termination, and 4 for a query failure.
 These codes are not an API and may change at any point.

--- a/e2e/ibazel.go
+++ b/e2e/ibazel.go
@@ -64,6 +64,7 @@ func (i *IBazelTester) Run(bazelArgs []string, target string) {
 	i.t.Helper()
 	i.run(target, bazelArgs, []string{
 		"--log_to_file=" + i.ibazelLogFile,
+		"--graceful_termination_wait_duration=1s",
 	})
 }
 
@@ -71,6 +72,7 @@ func (i *IBazelTester) RunWithProfiler(target string, profiler string) {
 	i.t.Helper()
 	i.run(target, []string{}, []string{
 		"--log_to_file=" + i.ibazelLogFile,
+		"--graceful_termination_wait_duration=1s",
 		"--profile_dev=" + profiler,
 	})
 }
@@ -79,6 +81,7 @@ func (i *IBazelTester) RunWithBazelFixCommands(target string) {
 	i.t.Helper()
 	i.run(target, []string{}, []string{
 		"--log_to_file=" + i.ibazelLogFile,
+		"--graceful_termination_wait_duration=1s",
 		"--run_output=true",
 		"--run_output_interactive=false",
 	})
@@ -202,6 +205,11 @@ func (i *IBazelTester) Kill() {
 	if err := i.cmd.Process.Kill(); err != nil {
 		panic(err)
 	}
+}
+
+func (i *IBazelTester) Signal(signum os.Signal) {
+	i.t.Helper()
+	i.cmd.Process.Signal(signum)
 }
 
 func (i *IBazelTester) build(target string, additionalArgs []string) {

--- a/e2e/termination/BUILD
+++ b/e2e/termination/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "go_default_test",
+    srcs = ["termination_test.go"],
+    data = [
+        "//ibazel",
+    ],
+    importpath = "github.com/bazelbuild/bazel-watcher/e2e/termination",
+    deps = [
+        "//e2e:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel_testing:go_default_library",
+    ],
+)

--- a/e2e/termination/termination_test.go
+++ b/e2e/termination/termination_test.go
@@ -1,0 +1,95 @@
+package termination
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/bazelbuild/bazel-watcher/e2e"
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+const signalHandler = `
+tail -f /dev/null & PID=$!
+_handler() { printf "$1."; kill $PID; }
+trap '_handler SIGTERM' TERM
+wait
+`
+
+const signalHandlerBroken = `
+trap -- '' SIGTERM
+tail -f /dev/null
+`
+
+const mainFiles = `
+-- BUILD.bazel --
+sh_binary(
+  name = "termination",
+  srcs = ["termination.sh"],
+)
+-- termination.sh --
+` + signalHandler
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: mainFiles,
+		SetUp: func() error {
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			if err := filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				if strings.HasSuffix(path, ".sh") {
+					if err := os.Chmod(path, 0777); err != nil {
+						return fmt.Errorf("Error os.Chmod(%q, 0777): %v", path, err)
+					}
+				}
+				return nil
+			}); err != nil {
+				fmt.Printf("Error walking dir: %v\n", err)
+				return err
+			}
+			return nil
+		},
+	})
+}
+
+func TestTerminationBasic(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	e2e.MustWriteFile(t, "termination.sh", "printf \"Started 1!\";"+signalHandler)
+	ibazel.Run([]string{}, "//:termination")
+	ibazel.ExpectOutput("Started 1!")
+	e2e.MustWriteFile(t, "termination.sh", "printf \"Started 2!\";"+signalHandler)
+
+	// Windows doesn't support signals unfortunately
+	if runtime.GOOS == "windows" {
+		ibazel.ExpectOutput("Started 1!Started 2!")
+		ibazel.Signal(syscall.SIGINT)
+		ibazel.ExpectOutput("Started 1!Started 2!")
+	} else {
+		ibazel.ExpectOutput("Started 1!SIGTERM.Started 2!")
+		ibazel.Signal(syscall.SIGINT)
+		ibazel.ExpectOutput("Started 1!SIGTERM.Started 2!SIGTERM.")
+	}
+	defer ibazel.Kill()
+}
+
+func TestTerminationTimeout(t *testing.T) {
+	ibazel := e2e.SetUp(t)
+	e2e.MustWriteFile(t, "termination.sh", "printf \"Started 1!\";"+signalHandlerBroken)
+	ibazel.Run([]string{}, "//:termination")
+	ibazel.ExpectOutput("Started 1!")
+	e2e.MustWriteFile(t, "termination.sh", "printf \"Started 2!\";"+signalHandlerBroken)
+	ibazel.Signal(syscall.SIGINT)
+	ibazel.ExpectOutput("Started 1!Started 2!")
+	defer ibazel.Kill()
+}

--- a/ibazel/command/command.go
+++ b/ibazel/command/command.go
@@ -16,25 +16,37 @@ package command
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/bazelbuild/bazel-watcher/bazel"
+	"github.com/bazelbuild/bazel-watcher/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/ibazel/process_group"
 )
 
-var execCommand = process_group.Command
-var bazelNew = bazel.New
+var (
+	execCommand  = process_group.Command
+	bazelNew     = bazel.New
+	waitDuration = flag.Duration(
+		"graceful_termination_wait_duration",
+		10*time.Second,
+		"Specify the duration to wait for a graceful termination before sending SIGKILL to the subprocess",
+	)
+)
 
 // Command is an object that wraps the logic of running a task in Bazel and
 // manipulating it.
 type Command interface {
 	Start(logFile *os.File) (*bytes.Buffer, error)
 	Terminate()
+	Kill()
 	BeforeRebuild()
 	AfterRebuild(logFile *os.File) *bytes.Buffer
 	IsSubprocessRunning() bool
@@ -91,4 +103,28 @@ func subprocessRunning(cmd *exec.Cmd) bool {
 	}
 
 	return true
+}
+
+func terminate(pg process_group.ProcessGroup) {
+	pg.Signal(syscall.SIGTERM)
+	done := make(chan bool, 1)
+	go func() {
+		select {
+		case <-time.After(*waitDuration):
+			log.Logf("The subprocess wasn't terminated within %s. Forcing to close.", *waitDuration)
+			kill(pg)
+		case <-done:
+			// The subprocess was terminated with SIGTERM
+		}
+	}()
+	pg.Wait()
+	done <- true
+	pg.Close()
+}
+
+func kill(pg process_group.ProcessGroup) {
+	if subprocessRunning(pg.RootProcess()) {
+		log.Logf("Sending SIGKILL to the subprocess")
+		pg.Signal(syscall.SIGKILL)
+	}
 }

--- a/ibazel/command/default_command.go
+++ b/ibazel/command/default_command.go
@@ -17,6 +17,7 @@ package command
 import (
 	"bytes"
 	"os"
+	"sync"
 
 	"github.com/bazelbuild/bazel-watcher/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/ibazel/process_group"
@@ -28,6 +29,7 @@ type defaultCommand struct {
 	bazelArgs   []string
 	args        []string
 	pg          process_group.ProcessGroup
+	termSync    sync.Once
 }
 
 // DefaultCommand is the normal mode of interacting with iBazel. If you start a
@@ -43,19 +45,20 @@ func DefaultCommand(startupArgs []string, bazelArgs []string, target string, arg
 }
 
 func (c *defaultCommand) Terminate() {
-	if c.pg != nil && !subprocessRunning(c.pg.RootProcess()) {
+	if !c.IsSubprocessRunning() {
+		c.pg = nil
 		return
 	}
-
-	// Kill it with fire by sending SIGKILL to the process PID which should
-	// propagate down to any subprocesses in the PGID (Process Group ID). To
-	// send to the PGID, send the signal to the negative of the process PID.
-	// Normally I would do this by calling c.cmd.Process.Signal, but that
-	// only goes to the PID not the PGID.
-	c.pg.Kill()
-	c.pg.Wait()
-	c.pg.Close()
+	c.termSync.Do(func() {
+		terminate(c.pg)
+	})
 	c.pg = nil
+}
+
+func (c *defaultCommand) Kill() {
+	if c.pg != nil {
+		kill(c.pg)
+	}
 }
 
 func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
@@ -77,6 +80,7 @@ func (c *defaultCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 		return outputBuffer, err
 	}
 	log.Log("Starting...")
+	c.termSync = sync.Once{}
 	return outputBuffer, nil
 }
 

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/bazelbuild/bazel-watcher/ibazel/log"
 	"github.com/bazelbuild/bazel-watcher/ibazel/process_group"
@@ -28,9 +29,9 @@ type notifyCommand struct {
 	startupArgs []string
 	bazelArgs   []string
 	args        []string
-
-	pg    process_group.ProcessGroup
-	stdin io.WriteCloser
+	pg          process_group.ProcessGroup
+	stdin       io.WriteCloser
+	termSync    sync.Once
 }
 
 // NotifyCommand is an alternate mode for starting a command. In this mode the
@@ -45,19 +46,20 @@ func NotifyCommand(startupArgs []string, bazelArgs []string, target string, args
 }
 
 func (c *notifyCommand) Terminate() {
-	if c.pg != nil && !subprocessRunning(c.pg.RootProcess()) {
+	if !c.IsSubprocessRunning() {
+		c.pg = nil
 		return
 	}
-
-	// Kill it with fire by sending SIGKILL to the process PID which should
-	// propagate down to any subprocesses in the PGID (Process Group ID). To
-	// send to the PGID, send the signal to the negative of the process PID.
-	// Normally I would do this by calling c.cmd.Process.Signal, but that
-	// only goes to the PID not the PGID.
-	c.pg.Kill()
-	c.pg.Wait()
-	c.pg.Close()
+	c.termSync.Do(func() {
+		terminate(c.pg)
+	})
 	c.pg = nil
+}
+
+func (c *notifyCommand) Kill() {
+	if c.pg != nil {
+		kill(c.pg)
+	}
 }
 
 func (c *notifyCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
@@ -85,6 +87,7 @@ func (c *notifyCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 		return outputBuffer, err
 	}
 	log.Log("Starting...")
+	c.termSync = sync.Once{}
 	return outputBuffer, nil
 }
 
@@ -94,7 +97,6 @@ func (c *notifyCommand) BeforeRebuild() {
 		log.Errorf("Error writing build to stdin: %s", err)
 	}
 }
-
 
 func (c *notifyCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {
 	b := bazelNew()

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -43,6 +43,11 @@ var osExit = os.Exit
 var bazelNew = bazel.New
 var commandDefaultCommand = command.DefaultCommand
 var commandNotifyCommand = command.NotifyCommand
+var exitMessages = map[os.Signal]string{
+	syscall.SIGINT:  "Subprocess killed from getting SIGINT (trigger SIGINT again to stop ibazel)",
+	syscall.SIGTERM: "Subprocess killed from getting SIGTERM",
+	syscall.SIGHUP:  "Subprocess killed from getting SIGHUP",
+}
 var mrunToFiles = flag.Bool("mrunToFiles", false, "Log mrun to file for simpler log reading")
 
 type State string
@@ -139,56 +144,46 @@ func (i *IBazel) handleSignals() {
 	// Got an OS signal (SIGINT, SIGTERM, SIGHUP).
 	sig := <-i.sigs
 
-	switch sig {
-	case syscall.SIGINT:
-		for _, cmd := range i.cmds {
-			if cmd.IsSubprocessRunning() {
-				cmd.Terminate()
-			}
-		}
-		if i.cmd != nil && i.cmd.IsSubprocessRunning() {
-			log.NewLine()
-			log.Log("Subprocess killed from getting SIGINT (trigger SIGINT again to stop ibazel)")
-			i.cmd.Terminate()
-		} else {
-			osExit(3)
-		}
-		break
-	case syscall.SIGTERM:
-		for _, cmd := range i.cmds {
-			if cmd.IsSubprocessRunning() {
-				cmd.Terminate()
-			}
-		}
-		if i.cmd != nil && i.cmd.IsSubprocessRunning() {
-			log.NewLine()
-			log.Log("Subprocess killed from getting SIGTERM")
-			i.cmd.Terminate()
-		}
+	if i.cmd == nil || !i.cmd.IsSubprocessRunning() {
 		osExit(3)
 		return
-	case syscall.SIGHUP:
-		for _, cmd := range i.cmds {
-			if cmd.IsSubprocessRunning() {
-				cmd.Terminate()
-			}
-		}
-		if i.cmd != nil && i.cmd.IsSubprocessRunning() {
-			log.NewLine()
-			log.Log("Subprocess killed from getting SIGHUP")
-			i.cmd.Terminate()
-		}
-		osExit(3)
-		return
-	default:
-		log.Fatal("Got a signal that wasn't handled. Please file a bug against bazel-watcher that describes how you did this. This is a big problem.")
 	}
 
-	i.interruptCount += 1
-	if i.interruptCount > 2 {
-		log.NewLine()
-		log.Fatal("Exiting from getting SIGINT 3 times")
-		osExit(3)
+	switch sig {
+	case syscall.SIGINT:
+		i.interruptCount++
+		switch {
+		case i.interruptCount > 2:
+			log.NewLine()
+			log.Fatal("Exiting from getting SIGINT 3 times")
+			osExit(3)
+		case i.interruptCount > 1:
+			for _, cmd := range i.cmds {
+				cmd.Kill()
+			}
+			i.cmd.Kill()
+		default:
+			go func() {
+				for _, cmd := range i.cmds {
+					cmd.Terminate()
+				}
+				i.cmd.Terminate()
+				log.NewLine()
+				log.Log(exitMessages[sig])
+			}()
+		}
+	case syscall.SIGTERM, syscall.SIGHUP:
+		go func() {
+			for _, cmd := range i.cmds {
+				cmd.Terminate()
+			}
+			i.cmd.Terminate()
+			log.NewLine()
+			log.Log(exitMessages[sig])
+			osExit(3)
+		}()
+	default:
+		log.Fatal("Got a signal that wasn't handled. Please file a bug against bazel-watcher that describes how you did this. This is a big problem.")
 	}
 }
 
@@ -370,6 +365,7 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 		log.Logf("%s %s", strings.Title(verb(command)), joinedTargets)
 		i.beforeCommand(targets, command)
 		outputBuffer, err := commandToRun(targets...)
+		i.interruptCount = 0
 		i.afterCommand(targets, command, err == nil, outputBuffer)
 		i.state = WAIT
 	}
@@ -445,10 +441,11 @@ func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands
 		} else {
 			torun = targets
 		}
-		
+
 		log.Logf("%s %s", strings.Title(verb(command)), strings.Join(torun, " "))
 		i.beforeCommand(torun, command)
 		outputBuffers, err := commandToRun(torun, debugArgs, argsLength)
+		i.interruptCount = 0
 		for _, buffer := range outputBuffers {
 			i.afterCommand(torun, command, err == nil, buffer)
 		}
@@ -551,7 +548,7 @@ func (i *IBazel) setupRun(target string, debugArg []string, argsLength int) comm
 		if len(debugArg) > 0 {
 			i.args = append(debugArg, i.args[len(i.args)-argsLength:len(i.args)]...)
 		} else if argsLength > -1 {
-			i.args = i.args[len(i.args)-argsLength:len(i.args)]
+			i.args = i.args[len(i.args)-argsLength : len(i.args)]
 		}
 		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
 	}
@@ -776,7 +773,7 @@ func dirWatchedByTarget(toWatchByTarget map[string][]string, targets []string, d
 			if len(dirStorage[dir]) == 0 {
 				delete(dirStorage, dir)
 			}
-			
+
 		}
 	}
 
@@ -804,7 +801,7 @@ func containsIdx(l []string, e string) int {
 // Delete idx element in string array a
 func deleteIdx(a []string, idx int) []string {
 	a[idx] = a[len(a)-1] // Copy last element to index i.
-	a[len(a)-1] = ""   // Erase last element (write zero value).
+	a[len(a)-1] = ""     // Erase last element (write zero value).
 	a = a[:len(a)-1]
 	return a
 }

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -361,7 +361,9 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 			i.state = RUN
 		}
 	case RUN:
-		i.cmd.BeforeRebuild()
+		if i.cmd != nil {
+			i.cmd.BeforeRebuild()
+		}
 		log.Logf("%s %s", strings.Title(verb(command)), joinedTargets)
 		i.beforeCommand(targets, command)
 		outputBuffer, err := commandToRun(targets...)

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -23,6 +23,7 @@ import (
 	"runtime/debug"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/protobuf/proto"
@@ -62,6 +63,24 @@ func assertEqual(t *testing.T, want, got interface{}, msg string) {
 		debug.PrintStack()
 	}
 }
+func assertOsExited(t *testing.T, osExitChan chan int) {
+	select {
+	case exitCode := <-osExitChan:
+		assertEqual(t, 3, exitCode, "Should have exited ibazel")
+	case <-time.After(time.Second):
+		t.Errorf("It should have os.Exit'd")
+		debug.PrintStack()
+	}
+}
+func assertNotOsExited(t *testing.T, osExitChan chan int) {
+	select {
+	case <-osExitChan:
+		t.Errorf("It shouldn't have os.Exit'd")
+		debug.PrintStack()
+	case <-time.After(time.Second):
+		// works as expected
+	}
+}
 
 type mockCommand struct {
 	startupArgs []string
@@ -72,6 +91,10 @@ type mockCommand struct {
 	notifiedOfChanges bool
 	started           bool
 	terminated        bool
+
+	signalChan  chan syscall.Signal
+	doTermChan  chan struct{}
+	didTermChan chan struct{}
 }
 
 func (m *mockCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
@@ -91,17 +114,34 @@ func (m *mockCommand) Terminate() {
 	if !m.started {
 		panic("Terminated before starting")
 	}
+	m.signalChan <- syscall.SIGTERM
+	<-m.doTermChan
 	m.terminated = true
+	m.didTermChan <- struct{}{}
+}
+func (m *mockCommand) Kill() {
+	if !m.started {
+		panic("Sending kill signal before terminating")
+	}
+	m.signalChan <- syscall.SIGKILL
 }
 func (m *mockCommand) assertTerminated(t *testing.T) {
-	if !m.terminated {
-		t.Errorf("Mock command wasn't terminated")
+	select {
+	case <-m.didTermChan:
+		// works as expected
+	case <-time.After(time.Second):
+		t.Errorf("A process wasn't terminated within assert timeout")
 		debug.PrintStack()
 	}
 }
-
+func (m *mockCommand) assertSignal(t *testing.T, signum syscall.Signal) {
+	if <-m.signalChan != signum {
+		t.Errorf("An incorrect signal was used to terminate a process")
+		debug.PrintStack()
+	}
+}
 func (m *mockCommand) IsSubprocessRunning() bool {
-	return m.started
+	return m.started && !m.terminated
 }
 
 var mockBazel *mock_bazel.MockBazel
@@ -384,9 +424,9 @@ func TestHandleSignals_SIGINTWithoutRunningCommand(t *testing.T) {
 	defer i.Cleanup()
 
 	// But we want to simulate the subprocess not dying
-	attemptedExit := 0
+	osExitChan := make(chan int, 1)
 	osExit = func(i int) {
-		attemptedExit = i
+		osExitChan <- i
 	}
 	assertEqual(t, i.cmd, nil, "There shouldn't be a subprocess running")
 
@@ -395,10 +435,10 @@ func TestHandleSignals_SIGINTWithoutRunningCommand(t *testing.T) {
 	i.handleSignals()
 
 	// Goroutine tests are kind of racey
-	assertEqual(t, attemptedExit, 3, "Should have exited ibazel")
+	assertOsExited(t, osExitChan)
 }
 
-func TestHandleSignals_SIGINT(t *testing.T) {
+func TestHandleSignals_SIGINTNormalTermination(t *testing.T) {
 	i := &IBazel{}
 	err := i.setup()
 	if err != nil {
@@ -407,35 +447,113 @@ func TestHandleSignals_SIGINT(t *testing.T) {
 	i.sigs = make(chan os.Signal, 1)
 	defer i.Cleanup()
 
-	// But we want to simulate the subprocess not dying
-	attemptedExit := 0
+	osExitChan := make(chan int, 1)
 	osExit = func(i int) {
-		attemptedExit = i
+		osExitChan <- i
 	}
 
-	var cmd *mockCommand
-	// Attempt to kill a task 2 times (but secretly resurrect the job from the
-	// dead to test the job not responding)
-	for j := 0; j < 2; j++ {
-		cmd = &mockCommand{}
-		cmd.Start(nil)
-		i.cmd = cmd
-
-		// This should kill the subprocess and simulate hitting ctrl-c
-		// First save the cmd so we can make assertions on it. It will be removed
-		// by the SIGINT
-		i.sigs <- syscall.SIGINT
-		i.handleSignals()
-
-		cmd.assertTerminated(t)
-		assertEqual(t, attemptedExit, 0, "It shouldn't have os.Exit'd")
+	cmd := &mockCommand{
+		signalChan:  make(chan syscall.Signal, 10),
+		doTermChan:  make(chan struct{}, 1),
+		didTermChan: make(chan struct{}, 1),
 	}
+	i.cmd = cmd
+	cmd.Start(nil)
 
-	// This should kill the job and go over the interrupt limit where exiting happens
+	// First ctrl-c sends custom signal (SIGTERM)
 	i.sigs <- syscall.SIGINT
 	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGTERM)
+	cmd.doTermChan <- struct{}{}
+	cmd.assertTerminated(t)
+	assertNotOsExited(t, osExitChan)
 
-	assertEqual(t, attemptedExit, 3, "Should have exited ibazel")
+	// Second ctrl-c terminates ibazel
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	assertOsExited(t, osExitChan)
+}
+
+func TestHandleSignals_SIGINTHitLimitTermination(t *testing.T) {
+	i := &IBazel{}
+	err := i.setup()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+	i.sigs = make(chan os.Signal, 1)
+	defer i.Cleanup()
+
+	osExitChan := make(chan int, 1)
+	osExit = func(i int) {
+		osExitChan <- i
+	}
+
+	cmd := &mockCommand{
+		signalChan:  make(chan syscall.Signal, 10),
+		doTermChan:  make(chan struct{}, 1),
+		didTermChan: make(chan struct{}, 1),
+	}
+	i.cmd = cmd
+	cmd.Start(nil)
+
+	// First ctrl-c sends custom signal (SIGTERM)
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGTERM)
+	assertNotOsExited(t, osExitChan)
+
+	// Second ctrl-c sends SIGKILL
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGKILL)
+	assertNotOsExited(t, osExitChan)
+
+	// Third ctrl-c terminates ibazel even if the subprocess is not closed
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	assertOsExited(t, osExitChan)
+}
+
+func TestHandleSignals_SIGINTForcefulTermination(t *testing.T) {
+	i := &IBazel{}
+	err := i.setup()
+	if err != nil {
+		t.Errorf("Error creating IBazel: %s", err)
+	}
+	i.sigs = make(chan os.Signal, 1)
+	defer i.Cleanup()
+
+	osExitChan := make(chan int, 1)
+
+	osExit = func(i int) {
+		osExitChan <- i
+	}
+	cmd := &mockCommand{
+		signalChan:  make(chan syscall.Signal, 10),
+		doTermChan:  make(chan struct{}, 1),
+		didTermChan: make(chan struct{}, 1),
+	}
+	i.cmd = cmd
+	cmd.Start(nil)
+
+	// First ctrl-c sends custom signal (SIGTERM)
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGTERM)
+	assertNotOsExited(t, osExitChan)
+
+	// Second ctrl-c sends SIGKILL
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGKILL)
+	cmd.doTermChan <- struct{}{}
+	cmd.assertTerminated(t)
+	assertNotOsExited(t, osExitChan)
+
+	// Yet another ctrl-c terminates ibazel
+	i.sigs <- syscall.SIGINT
+	i.handleSignals()
+	assertOsExited(t, osExitChan)
 }
 
 func TestHandleSignals_SIGTERM(t *testing.T) {
@@ -447,20 +565,23 @@ func TestHandleSignals_SIGTERM(t *testing.T) {
 	i.sigs = make(chan os.Signal, 1)
 	defer i.Cleanup()
 
-	// Now test sending SIGTERM
-	attemptedExit := false
+	osExitChan := make(chan int, 1)
 	osExit = func(i int) {
-		attemptedExit = true
+		osExitChan <- i
 	}
-	attemptedExit = false
 
-	cmd := &mockCommand{}
-	cmd.Start(nil)
+	cmd := &mockCommand{
+		signalChan:  make(chan syscall.Signal, 10),
+		doTermChan:  make(chan struct{}, 1),
+		didTermChan: make(chan struct{}, 1),
+	}
 	i.cmd = cmd
+	cmd.Start(nil)
 
 	i.sigs <- syscall.SIGTERM
 	i.handleSignals()
+	cmd.assertSignal(t, syscall.SIGTERM)
+	cmd.doTermChan <- struct{}{}
 	cmd.assertTerminated(t)
-
-	assertEqual(t, attemptedExit, true, "Should have exited ibazel")
+	assertOsExited(t, osExitChan)
 }

--- a/ibazel/ibazel_test.go
+++ b/ibazel/ibazel_test.go
@@ -81,6 +81,8 @@ func (m *mockCommand) Start(logFile *os.File) (*bytes.Buffer, error) {
 	m.started = true
 	return nil, nil
 }
+func (m *mockCommand) BeforeRebuild() {
+}
 func (m *mockCommand) AfterRebuild(logFile *os.File) *bytes.Buffer {
 	m.notifiedOfChanges = true
 	return nil

--- a/ibazel/process_group/process_group.go
+++ b/ibazel/process_group/process_group.go
@@ -27,6 +27,7 @@ package process_group
 
 import (
 	"os/exec"
+	"syscall"
 )
 
 // ProcessGroup represents a tree of processes that can be terminated
@@ -34,7 +35,7 @@ import (
 type ProcessGroup interface {
 	RootProcess() *exec.Cmd
 	Start() error
-	Kill() error
+	Signal(signm syscall.Signal) error
 	Wait() error
 	Close() error
 	CombinedOutput() ([]byte, error)

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
 // +build !windows
 
 package process_group
@@ -41,8 +42,11 @@ func (pg *unixProcessGroup) Start() error {
 	return pg.root.Start()
 }
 
-func (pg *unixProcessGroup) Kill() error {
-	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGKILL)
+func (pg *unixProcessGroup) Signal(signum syscall.Signal) error {
+	// Send the signal to the process PID which should propagate down to any
+	// subprocesses in the PGID (Process Group ID). To send to the PGID, send the
+	// singal to the negative of the process ID.
+	return syscall.Kill(-pg.root.Process.Pid, signum)
 }
 
 func (pg *unixProcessGroup) Wait() error {

--- a/ibazel/process_group/process_group_windows.go
+++ b/ibazel/process_group/process_group_windows.go
@@ -91,8 +91,8 @@ func (pg *winProcessGroup) Start() error {
 	return nil
 }
 
-func (pg *winProcessGroup) Kill() error {
-	log.Println("Kill()")
+func (pg *winProcessGroup) Signal(signum syscall.Signal) error {
+	// signum is ignored on Windows as there's no support for signals
 	if pg.job == 0 {
 		return errors.New("job not started")
 	}


### PR DESCRIPTION
The upstream PR bazelbuild#405 updated `ibazel` to use `SIGTERM`, rather than `SIGKILL`, to shutdown subprocesses (but keeping `SIGKILL` as a fallback). This is desirable behavior because it gives subprocesses the opportunity to clean up resources. This applies the same changes from that PR with merge conflicts resolved by hand. A couple other commits apply small bug fixes to restabilize tests.