### PR TITLE
Robustly handle both i.cmd and i.cmds in handleSingals

### DIFF
--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -140,11 +140,52 @@ func New() (*IBazel, error) {
 	return i, nil
 }
 
+func (i *IBazel) isAnyCmdRunning() bool {
+	if i.cmd != nil && i.cmd.IsSubprocessRunning() {
+		return true
+	} else if i.cmds != nil {
+		for _, cmd := range i.cmds {
+			if cmd.IsSubprocessRunning() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (i *IBazel) terminateAllCmds() {
+	if i.cmd != nil {
+		i.cmd.Terminate()
+	}
+	if i.cmds != nil {
+		for _, cmd := range i.cmds {
+			// Terminating a Command is potentially slow as we wait for the Command to gracefully terminate or
+			// waitDuration to elapse. Thus, we start a new goroutine for each so that this waiting can happen in
+			// parallel.
+			go func(cmd command.Command) {
+				cmd.Terminate()
+			}(cmd)
+		}
+	}
+}
+
+func (i *IBazel) killAllCmds() {
+	if i.cmd != nil {
+		i.cmd.Kill()
+	}
+	if i.cmds != nil {
+		for _, cmd := range i.cmds {
+			cmd.Kill()
+		}
+	}
+}
+
 func (i *IBazel) handleSignals() {
 	// Got an OS signal (SIGINT, SIGTERM, SIGHUP).
 	sig := <-i.sigs
 
-	if i.cmd == nil || !i.cmd.IsSubprocessRunning() {
+	if !i.isAnyCmdRunning() {
 		osExit(3)
 		return
 	}
@@ -158,26 +199,17 @@ func (i *IBazel) handleSignals() {
 			log.Fatal("Exiting from getting SIGINT 3 times")
 			osExit(3)
 		case i.interruptCount > 1:
-			for _, cmd := range i.cmds {
-				cmd.Kill()
-			}
-			i.cmd.Kill()
+			i.killAllCmds()
 		default:
 			go func() {
-				for _, cmd := range i.cmds {
-					cmd.Terminate()
-				}
-				i.cmd.Terminate()
+				i.terminateAllCmds()
 				log.NewLine()
 				log.Log(exitMessages[sig])
 			}()
 		}
 	case syscall.SIGTERM, syscall.SIGHUP:
 		go func() {
-			for _, cmd := range i.cmds {
-				cmd.Terminate()
-			}
-			i.cmd.Terminate()
+			i.terminateAllCmds()
 			log.NewLine()
 			log.Log(exitMessages[sig])
 			osExit(3)

--- a/ibazel/process_group/process_group.go
+++ b/ibazel/process_group/process_group.go
@@ -35,7 +35,7 @@ import (
 type ProcessGroup interface {
 	RootProcess() *exec.Cmd
 	Start() error
-	Signal(signm syscall.Signal) error
+	Signal(signum syscall.Signal) error
 	Wait() error
 	Close() error
 	CombinedOutput() ([]byte, error)


### PR DESCRIPTION
When `ibazel` is run with `mrun` (rather than `run`), the `cmds` variable (rathern than `cmd`) is populated with the commands being run (rather than `cmd`). Since the same `handleSignals` is used for either command, `handleSignals` cannot assume that either is not null and must also check both to know if any commands are still running.