### PR TITLE
Wait for all commands to end before exiting

### DIFF
--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -159,14 +160,18 @@ func (i *IBazel) terminateAllCmds() {
 		i.cmd.Terminate()
 	}
 	if i.cmds != nil {
+		var wg sync.WaitGroup
 		for _, cmd := range i.cmds {
 			// Terminating a Command is potentially slow as we wait for the Command to gracefully terminate or
 			// waitDuration to elapse. Thus, we start a new goroutine for each so that this waiting can happen in
-			// parallel.
+			// parallel. The WaitGroup is to ensure that all Commands have ended before handleSignals might exit ibazel.
+			wg.Add(1)
 			go func(cmd command.Command) {
+				defer wg.Done()
 				cmd.Terminate()
 			}(cmd)
 		}
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
The previous PR parallelized shutdown of Commands. Unfortunately, it neglected to block `ibazel` from exiting in the SIGTERM/SIGHUP case until everything was actually shutdown. This creates a race condition where some commands may not be terminated. This PR fixes that by using a `WaitGroup` to ensure that all of the Commands have been shutdown before `terminateAllCommands` can return (and `handleSignal` can exit).