### PR TITLE
Don't terminate everything when rebuilding targets

### DIFF
--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -468,17 +468,17 @@ func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands
 			i.state = RUN
 		}
 	case RUN:
-		if i.cmds != nil {
-			for _, target := range targets {
-				i.cmds[target].BeforeRebuild()
-			}
-		}
-
 		var torun []string
 		if i.prevDir != "" && i.firstBuildPassed {
 			torun = i.srcDirToWatch[i.prevDir]
 		} else {
 			torun = targets
+		}
+
+		if i.cmds != nil {
+			for _, target := range torun {
+				i.cmds[target].BeforeRebuild()
+			}
 		}
 
 		log.Logf("%s %s", strings.Title(verb(command)), strings.Join(torun, " "))


### PR DESCRIPTION
Only call `BeforeRebuild` (and thus terminate) the `Command`s for targets about to be rebuilt in `iterationMultiple`, rather than for all `Command`s.