### PR TITLE
Terminate services in parallel and fix race condition

### DIFF
--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -424,12 +424,14 @@ func (i *IBazel) iterationMultiple(commandString string, commandToRun runnableCo
 			if _, ok := i.filesWatched[i.sourceFileWatcher][e.Name]; ok && e.Op&modifyingEvents != 0 {
 				log.Logf("\nChanged: %q. Rebuilding...", e.Name)
 				i.changeDetected(targets, "source", e.Name)
+				i.prevDir, _ = filepath.Split(e.Name)
 				i.state = DEBOUNCE_RUN
 			}
 		case e := <-i.buildFileWatcher.Events():
 			if _, ok := i.filesWatched[i.buildFileWatcher][e.Name]; ok && e.Op&modifyingEvents != 0 {
 				log.Logf("\nBuild graph changed: %q. Requerying...", e.Name)
 				i.changeDetected(targets, "graph", e.Name)
+				i.prevDir, _ = filepath.Split(e.Name)
 				i.state = DEBOUNCE_QUERY
 			}
 		}

--- a/internal/ibazel/ibazel.go
+++ b/internal/ibazel/ibazel.go
@@ -415,7 +415,7 @@ func (i *IBazel) iteration(command string, commandToRun runnableCommand, targets
 	}
 }
 
-func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands, targets []string, debugArgs [][]string, argsLength int) {
+func (i *IBazel) iterationMultiple(commandString string, commandToRun runnableCommands, targets []string, debugArgs [][]string, argsLength int) {
 	log.Logf("State: %s", i.state)
 	switch i.state {
 	case WAIT:
@@ -481,17 +481,24 @@ func (i *IBazel) iterationMultiple(command string, commandToRun runnableCommands
 		}
 
 		if i.cmds != nil {
+			var wg sync.WaitGroup
 			for _, target := range torun {
-				i.cmds[target].BeforeRebuild()
+				// BeforeRebuild terminates the target command, which can take a while. We want to kick these off in parallel
+				wg.Add(1)
+				go func(cmd command.Command) {
+					defer wg.Done()
+					cmd.BeforeRebuild()
+				}(i.cmds[target])
 			}
+			wg.Wait()
 		}
 
-		log.Logf("%s %s", strings.Title(verb(command)), strings.Join(torun, " "))
-		i.beforeCommand(torun, command)
+		log.Logf("%s %s", strings.Title(verb(commandString)), strings.Join(torun, " "))
+		i.beforeCommand(torun, commandString)
 		outputBuffers, err := commandToRun(torun, debugArgs, argsLength)
 		i.interruptCount = 0
 		for _, buffer := range outputBuffers {
-			i.afterCommand(torun, command, err == nil, buffer)
+			i.afterCommand(torun, commandString, err == nil, buffer)
 		}
 		i.prevDir = ""
 		i.state = WAIT


### PR DESCRIPTION
Primary: @chill389cc 

### Why
2 big pain points this PR seeks to solve:
1. rebuilding lots of services is really slow and happens sequentially
2. Sometimes, all services are restarted when only a subset should be

### What
Basically what the commits say:
- Terminate services in parallel when rebuilding instead of sequentially. Kick off a bunch of threads to do so.
- Solve the race condition that causes all services to be restarted instead of just a subset

### Test Plan
- compiled ibazel locally with this branch and pointed lucid-start to use it.
Validate services restart in parallel:
- lucid-start
- echo "trait abc" >> src/jvm/com/lucidchart/service/common/core/util/DomainHelper.scala
- Watch all services die immediately :partying_face: 
Validate race condition is gone
- Without changes:
  - lucid-start
  - echo "console.log(\"testing\");" >> cake/app/webroot/ts/types/array.ts
  - check that all services restart (only document-storage-service should)
- With changes:
  - lucid-start
  - echo "console.log(\"testing\");" >> cake/app/webroot/ts/types/array.ts
  - check that only document-storage-service restarts.
  - (Also check a few other edits to make sure that other services restart when dependencies change)